### PR TITLE
allow kfz24 param converter as valid param converter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,13 @@ class Configuration implements ConfigurationInterface
         $rootNode->setBuilder(new AllowExtraPropertiesNodeBuilder());
 
         $rootNode->children()
+            ->arrayNode('allowedParamConverters')
+                ->prototype('array')
+                    ->children()
+                        ->scalarNode('name')->isRequired()->end()
+                    ->end()
+                ->end()
+            ->end()
             ->arrayNode('definitionAliases')
                 ->defaultValue(array())
                 ->prototype("array")

--- a/DependencyInjection/DrawSwaggerExtension.php
+++ b/DependencyInjection/DrawSwaggerExtension.php
@@ -40,6 +40,14 @@ class DrawSwaggerExtension extends Extension implements PrependExtensionInterfac
                 [$alias['class'], $alias['alias']]
             );
         }
+
+        $allowedParamConverters = $container->getParameter('draw.swagger.extractor.param_converter_extractor.allowed');
+
+        foreach ($config['allowedParamConverters'] as $key => $paramConverter) {
+            $allowedParamConverters[] = $paramConverter['name'];
+        }
+
+        $container->setParameter('draw.swagger.extractor.param_converter_extractor.allowed', $allowedParamConverters);
     }
 
     /**

--- a/Extractor/ParamConverterExtractor.php
+++ b/Extractor/ParamConverterExtractor.php
@@ -156,7 +156,10 @@ class ParamConverterExtractor implements ExtractorInterface
                     return false;
                 }
 
-                return $converter->getConverter() == "fos_rest.request_body";
+                return in_array(
+                    $converter->getConverter(),
+                    ["fos_rest.request_body", "kfz24.commons.json_schema.request_body"]
+                );
             }
         );
 

--- a/Extractor/ParamConverterExtractor.php
+++ b/Extractor/ParamConverterExtractor.php
@@ -25,11 +25,24 @@ class ParamConverterExtractor implements ExtractorInterface
      * @var GroupHierarchy
      */
     private $groupHierarchy;
+    /**
+     * @var array
+     */
+    private $allowedParamConverters;
 
-    public function __construct(Reader $reader, GroupHierarchy $groupHierarchy)
-    {
+    /**
+     * @param \Doctrine\Common\Annotations\Reader $reader
+     * @param \Draw\DrawBundle\Serializer\GroupHierarchy $groupHierarchy
+     * @param array $allowedParamConverters
+     */
+    public function __construct(
+        Reader $reader,
+        GroupHierarchy $groupHierarchy,
+        array $allowedParamConverters = ["fos_rest.request_body"]
+    ) {
         $this->reader = $reader;
         $this->groupHierarchy = $groupHierarchy;
+        $this->allowedParamConverters = $allowedParamConverters;
     }
 
     /**
@@ -156,10 +169,7 @@ class ParamConverterExtractor implements ExtractorInterface
                     return false;
                 }
 
-                return in_array(
-                    $converter->getConverter(),
-                    ["fos_rest.request_body", "kfz24.commons.json_schema.request_body"]
-                );
+                return in_array($converter->getConverter(), $this->allowedParamConverters);
             }
         );
 

--- a/Resources/config/swagger.yml
+++ b/Resources/config/swagger.yml
@@ -9,6 +9,7 @@ parameters:
     draw.swagger.extractor.param_converter_extractor.class: Draw\SwaggerBundle\Extractor\ParamConverterExtractor
     draw.swagger.extrator.type_schema_extractor.class: Draw\Swagger\Extraction\Extractor\TypeSchemaExtractor
     draw.swagger.extrator.fos_rest_view_operation_extractor.class: Draw\SwaggerBundle\Extractor\FOSRestViewOperationExtractor
+    draw.swagger.extractor.param_converter_extractor.allowed: ["fos_rest.request_body"]
 
 services:
     draw.swagger:
@@ -102,7 +103,7 @@ services:
 
     draw.swagger.extractor.param_converter_extractor:
         class: '%draw.swagger.extractor.param_converter_extractor.class%'
-        arguments: ['@annotations.reader', '@draw.serializer.group_hierarchy']
+        arguments: ['@annotations.reader', '@draw.serializer.group_hierarchy', '%draw.swagger.extractor.param_converter_extractor.allowed%']
         tags:
             - { name: swagger.extractor }
 


### PR DESCRIPTION
Since we have our own param converter with additional features all action which would use him where not longer showing the body input field in swagger